### PR TITLE
Don't run nodes with empty input

### DIFF
--- a/src/pipedown/dag/dag_tools.py
+++ b/src/pipedown/dag/dag_tools.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Union
 from pipedown.nodes.base.cache import Cache
 from pipedown.nodes.base.input import Input
 from pipedown.nodes.base.primary import Primary
-from pipedown.utils.empty import is_empty
+from pipedown.utils.empty import EMPTY, is_empty
 
 
 def run_dag(

--- a/src/pipedown/dag/dag_tools.py
+++ b/src/pipedown/dag/dag_tools.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Union
 from pipedown.nodes.base.cache import Cache
 from pipedown.nodes.base.input import Input
 from pipedown.nodes.base.primary import Primary
-from pipedown.utils.empty import EMPTY
+from pipedown.utils.empty import is_empty
 
 
 def run_dag(
@@ -110,7 +110,7 @@ def get_dag_eval_order(
 
 
 def run_node(node, node_inputs, mode):
-    if node_inputs is EMPTY:  # don't run nodes with empty input
+    if is_empty(node_inputs):  # don't run nodes with empty input
         return EMPTY
     if isinstance(node, Primary):
         return node.run(node_inputs, mode)


### PR DESCRIPTION
Checking if an output is empty by comparing to the sentinel object via `is EMPTY` doesn't work because sometimes it's a `deepcopy`.